### PR TITLE
Change find by find_by_id in application_controller

### DIFF
--- a/app/controllers/socializer/application_controller.rb
+++ b/app/controllers/socializer/application_controller.rb
@@ -13,7 +13,7 @@ module Socializer
     private
 
     def current_user
-      @current_user ||= Person.find_by_id(cookies[:user_id]) if cookies[:user_id].present?
+      @current_user ||= Person.find_by(id: cookies[:user_id]) if cookies[:user_id].present?
     end
 
     def signed_in?


### PR DESCRIPTION
An error occurs when you reset database and you didn't logoff. User id is not remove from cookie and we try to find a Person with id who doesn't exit. find_by_id return nil if not found.
